### PR TITLE
Enable student task submissions

### DIFF
--- a/app/Http/Controllers/AlumnoController.php
+++ b/app/Http/Controllers/AlumnoController.php
@@ -3,12 +3,61 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use App\Models\Alumno;
+use App\Models\Subtema;
+use App\Models\Entrega;
+use Illuminate\Support\Facades\Storage;
 
 class AlumnoController extends Controller
 {
     public function inicio(Request $request)
     {
         $tab = $request->query('tab', 'tareas');
-        return view('alumno.inicio', compact('tab'));
+        $alumno = Alumno::where('id_user', Auth::id())->first();
+
+        if ($alumno) {
+            $alumno->load([
+                'plan.temas.subtemas' => function ($query) use ($alumno) {
+                    $query->with(['entregas' => function ($q) use ($alumno) {
+                        $q->where('id_alumno', $alumno->id);
+                    }]);
+                },
+            ]);
+        }
+
+        return view('alumno.inicio', compact('tab', 'alumno'));
+    }
+
+    public function entregarTarea(Request $request, $subtema)
+    {
+        $alumno = Alumno::where('id_user', Auth::id())->firstOrFail();
+        $subtema = Subtema::findOrFail($subtema);
+
+        $request->validate([
+            'contenido' => 'required|string',
+            'archivos' => 'nullable|array|max:4',
+            'archivos.*' => 'file|max:2048',
+        ]);
+
+        if (Entrega::where('id_subtema', $subtema->id)->where('id_alumno', $alumno->id)->exists()) {
+            return back()->with('error', 'Ya enviaste esta tarea');
+        }
+
+        $paths = [];
+        if ($request->hasFile('archivos')) {
+            foreach ($request->file('archivos') as $file) {
+                $paths[] = $file->store('entregas', 'public');
+            }
+        }
+
+        Entrega::create([
+            'id_subtema' => $subtema->id,
+            'id_alumno' => $alumno->id,
+            'contenido' => $request->contenido,
+            'rutas' => $paths,
+        ]);
+
+        return back()->with('success', 'Tarea enviada');
     }
 }

--- a/app/Http/Controllers/MaestroController.php
+++ b/app/Http/Controllers/MaestroController.php
@@ -6,6 +6,7 @@ use App\Models\Plan;
 use App\Models\Tema;
 use App\Models\Subtema;
 use App\Models\Maestro;
+use App\Models\Alumno;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
@@ -185,5 +186,37 @@ class MaestroController extends Controller
             $subtema->save();
         }
         return back()->with('success', 'Archivo eliminado');
+    }
+
+    /**
+     * Asigna un plan a uno o varios alumnos del maestro.
+     */
+    public function asignarPlan(Request $request)
+    {
+        $request->validate([
+            'plan' => 'required|integer|exists:planes,id',
+            'alumnos' => 'required|array',
+            'alumnos.*' => 'integer|exists:alumnos,id',
+        ]);
+
+        $maestro = Maestro::where('id_user', Auth::id())->first();
+        if (!$maestro) {
+            return back()->with('error', 'No tienes un perfil de maestro.');
+        }
+
+        // Verifica que el plan pertenezca al maestro
+        $plan = Plan::where('id', $request->plan)
+            ->where('id_maestro', $maestro->id)
+            ->firstOrFail();
+
+        // Actualiza solo alumnos del maestro
+        Alumno::whereIn('id', $request->alumnos)
+            ->where('id_maestro', $maestro->id)
+            ->update(['id_plan' => $plan->id]);
+
+        return redirect()->route('maestro.inicio', [
+            'tab' => 'planes',
+            'subtab' => 'asignar_plan',
+        ])->with('success', 'Plan asignado correctamente');
     }
 }

--- a/resources/views/alumno/partials/tareas.blade.php
+++ b/resources/views/alumno/partials/tareas.blade.php
@@ -1,12 +1,77 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
-</head>
-<body>
-    <h1>Revisión</h1>
-    <p>Contenido de la pestaña de revisión.</p>
-</body>
-</html>
+@php
+    $plan = $alumno?->plan;
+@endphp
+
+@if(!$plan)
+    <div class="text-center text-gray-500">
+        Solicita que se te asigne un plan.
+    </div>
+@else
+    <div class="space-y-6">
+        <h2 class="text-center text-2xl font-bold text-blue-900">{{ $plan->nombre }}</h2>
+        @foreach($plan->temas as $tema)
+            <div class="border rounded-lg p-4 bg-gray-50">
+                <h3 class="text-lg font-semibold text-blue-800">{{ $tema->nombre }}</h3>
+                @if($tema->descripcion)
+                    <p class="text-sm text-gray-600 mb-2">{{ $tema->descripcion }}</p>
+                @endif
+                @foreach($tema->subtemas as $subtema)
+                    @php $entrega = $subtema->entregas->first(); @endphp
+                    <div class="mt-3 pl-4 border-l-4 border-blue-300" x-data="{ open: false }">
+                        <h4 class="font-medium text-blue-700">{{ $subtema->nombre }}</h4>
+                        @if($subtema->descripcion)
+                            <p class="text-sm text-gray-600">{{ $subtema->descripcion }}</p>
+                        @endif
+                        @if($subtema->rutas)
+                            <ul class="list-disc ml-5 mt-1 text-sm">
+                                @foreach($subtema->rutas as $ruta)
+                                    <li>
+                                        <a href="{{ asset('storage/'.$ruta) }}" target="_blank" class="flex items-center gap-1 text-blue-600 hover:underline max-w-[150px]">
+                                            <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" d="M7 2h6l5 5v13a2 2 0 01-2 2H7a2 2 0 01-2-2V4a2 2 0 012-2z" />
+                                            </svg>
+                                            <span class="truncate">{{ basename($ruta) }}</span>
+                                        </a>
+                                    </li>
+                                @endforeach
+                            </ul>
+                        @endif
+
+                        @if($entrega)
+                            <div class="mt-2 bg-green-50 border-l-4 border-green-500 p-2">
+                                <p class="text-sm font-semibold text-green-700">Tu entrega</p>
+                                <p class="text-sm text-gray-700 whitespace-pre-line">{{ $entrega->contenido }}</p>
+                                @if($entrega->rutas)
+                                    <ul class="list-disc ml-5 mt-1 text-sm">
+                                        @foreach($entrega->rutas as $eruta)
+                                            <li>
+                                                <a href="{{ asset('storage/'.$eruta) }}" target="_blank" class="flex items-center gap-1 text-blue-600 hover:underline max-w-[150px]">
+                                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M7 2h6l5 5v13a2 2 0 01-2 2H7a2 2 0 01-2-2V4a2 2 0 012-2z" />
+                                                    </svg>
+                                                    <span class="truncate">{{ basename($eruta) }}</span>
+                                                </a>
+                                            </li>
+                                        @endforeach
+                                    </ul>
+                                @endif
+                            </div>
+                        @else
+                            <div class="mt-2" x-data="{ open: false }">
+                                <button type="button" @click="open = !open" class="text-sm text-blue-600 underline">Entregar tarea</button>
+                                <form x-show="open" x-transition method="POST" action="{{ route('alumno.subtemas.entregar', $subtema->id) }}" enctype="multipart/form-data" class="mt-2 space-y-2">
+                                    @csrf
+                                    <textarea name="contenido" rows="3" class="w-full border rounded p-2" required></textarea>
+                                    <input type="file" name="archivos[]" multiple class="w-full border" accept="*">
+                                    <p class="text-xs text-gray-500">Máx. 4 archivos, 2MB cada uno.</p>
+                                    <button type="submit" class="bg-blue-600 text-white px-3 py-1 rounded">Enviar</button>
+                                </form>
+                            </div>
+                        @endif
+                    </div>
+                @endforeach
+            </div>
+        @endforeach
+    </div>
+@endif
+

--- a/resources/views/maestro/partials/planes/asignar_plan.blade.php
+++ b/resources/views/maestro/partials/planes/asignar_plan.blade.php
@@ -1,3 +1,49 @@
-<div class="p-4 text-center text-gray-500">
-    (Aquí irá la asignación de planes)
+@php
+    use Illuminate\Support\Facades\Auth;
+    use App\Models\Maestro;
+    use App\Models\Plan;
+    use App\Models\Alumno;
+
+    $maestro = Maestro::where('id_user', Auth::id())->first();
+    $planes = $maestro ? Plan::where('id_maestro', $maestro->id)->orderBy('nombre')->get() : collect();
+    $alumnos = $maestro ? Alumno::where('id_maestro', $maestro->id)->whereNull('id_plan')->orderBy('name')->get() : collect();
+@endphp
+
+<div class="p-4 max-w-xl mx-auto">
+    @if(session('success'))
+        <div class="bg-green-100 text-green-800 p-2 mb-4 rounded shadow text-center">{{ session('success') }}</div>
+    @elseif(session('error'))
+        <div class="bg-red-100 text-red-800 p-2 mb-4 rounded shadow text-center">{{ session('error') }}</div>
+    @endif
+
+    <form method="POST" action="{{ route('maestro.asignar_plan') }}" class="space-y-4">
+        @csrf
+        <div>
+            <label class="block font-semibold mb-1">Plan</label>
+            <select name="plan" class="w-full border rounded p-2" required>
+                <option value="">Selecciona un plan</option>
+                @foreach($planes as $plan)
+                    <option value="{{ $plan->id }}">{{ $plan->nombre }}</option>
+                @endforeach
+            </select>
+        </div>
+
+        <div>
+            <label class="block font-semibold mb-1">Alumnos sin plan</label>
+            <div class="max-h-60 overflow-y-auto border rounded p-2 space-y-1">
+                @forelse($alumnos as $alumno)
+                    <label class="flex items-center gap-2">
+                        <input type="checkbox" name="alumnos[]" value="{{ $alumno->id }}" class="rounded">
+                        <span>{{ $alumno->name }}</span>
+                    </label>
+                @empty
+                    <p class="text-gray-500 text-sm">No hay alumnos disponibles.</p>
+                @endforelse
+            </div>
+        </div>
+
+        @if($planes->count() && $alumnos->count())
+            <button type="submit" class="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 transition">Asignar Plan</button>
+        @endif
+    </form>
 </div>

--- a/resources/views/maestro/partials/planes/crear_plan.blade.php
+++ b/resources/views/maestro/partials/planes/crear_plan.blade.php
@@ -143,7 +143,12 @@
                                     @if($subtema->rutas)
                                         @foreach($subtema->rutas as $i => $ruta)
                                             <div class="flex items-center gap-1 bg-blue-100 rounded px-2 py-1">
-                                                <a href="{{ asset('storage/'.$ruta) }}" target="_blank" class="underline text-blue-600 text-xs truncate max-w-[90px]">{{ basename($ruta) }}</a>
+                                                <a href="{{ asset('storage/'.$ruta) }}" target="_blank" class="flex items-center gap-1 text-blue-600 hover:underline text-xs max-w-[90px]">
+                                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M7 2h6l5 5v13a2 2 0 01-2 2H7a2 2 0 01-2-2V4a2 2 0 012-2z" />
+                                                    </svg>
+                                                    <span class="truncate">{{ basename($ruta) }}</span>
+                                                </a>
                                                 <form method="POST" action="{{ route('maestro.subtemas.deletefile', $subtema->id) }}" onsubmit="return confirm('¿Eliminar este archivo?')">
                                                     @csrf
                                                     <input type="hidden" name="file_index" value="{{ $i }}">

--- a/resources/views/maestro/partials/planes/editar_plan.blade.php
+++ b/resources/views/maestro/partials/planes/editar_plan.blade.php
@@ -104,8 +104,12 @@
                                     <ul class="list-disc list-inside text-xs text-gray-600">
                                         <template x-for="ruta in subtema.rutas" :key="ruta">
                                             <li>
-                                                <a :href="'{{ asset('') }}' + ruta" target="_blank" class="text-blue-600 underline break-all"
-                                                    x-text="ruta.split('/').pop()"></a>
+                                                <a :href="'{{ asset('') }}' + ruta" target="_blank" class="flex items-center gap-1 text-blue-600 hover:underline">
+                                                    <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" d="M7 2h6l5 5v13a2 2 0 01-2 2H7a2 2 0 01-2-2V4a2 2 0 012-2z" />
+                                                    </svg>
+                                                    <span class="truncate max-w-[90px]" x-text="ruta.split('/').pop()"></span>
+                                                </a>
                                             </li>
                                         </template>
                                     </ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -78,6 +78,9 @@ Route::middleware(['rol:maestro'])->group(function () {
     Route::post('/maestro/subtemas/{id}/delete', [MaestroController::class, 'eliminarSubtema'])->name('maestro.subtemas.delete');
     Route::post('/maestro/subtemas/{id}/file', [MaestroController::class, 'subtemaAgregarArchivo'])->name('maestro.subtemas.addfile');
     Route::post('/maestro/subtemas/{id}/file-delete', [MaestroController::class, 'subtemaEliminarArchivo'])->name('maestro.subtemas.deletefile');
+
+    // Asignar plan a alumnos
+    Route::post('/maestro/asignar-plan', [MaestroController::class, 'asignarPlan'])->name('maestro.asignar_plan');
 });
 
 
@@ -85,6 +88,7 @@ Route::middleware(['rol:maestro'])->group(function () {
 // Panel alumno protegido
 Route::middleware(['rol:alumno'])->group(function () {
     Route::get('/alumno/inicio', [AlumnoController::class, 'inicio'])->name('alumno.inicio');
+    Route::post('/alumno/subtemas/{subtema}/entregar', [AlumnoController::class, 'entregarTarea'])->name('alumno.subtemas.entregar');
 });
 
 Route::get('/nada', function () {


### PR DESCRIPTION
## Summary
- load a student's deliveries when showing the plan
- allow posting a delivery for a subtopic
- show existing submissions or a form to submit one
- add route for posting deliveries

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405c895ea08324af7982e1095298c1