### PR TITLE
Implement dynamic file inputs for tarea

### DIFF
--- a/app/Models/Lista.php
+++ b/app/Models/Lista.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Lista extends Model
+{
+    public $timestamps = true;
+
+    protected $table = 'listas';
+
+    protected $fillable = [
+        'id_alumno',
+        'id_empresa',
+        'fecha',
+        'estado',
+    ];
+
+    protected $casts = [
+        'fecha' => 'date',
+    ];
+
+    public function alumno(): BelongsTo
+    {
+        return $this->belongsTo(Alumno::class, 'id_alumno');
+    }
+
+    public function empresa(): BelongsTo
+    {
+        return $this->belongsTo(Empresa::class, 'id_empresa');
+    }
+}

--- a/database/migrations/2025_06_02_150000_create_listas_table.php
+++ b/database/migrations/2025_06_02_150000_create_listas_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('listas', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('id_alumno')
+                  ->constrained('alumnos')
+                  ->onDelete('cascade');
+            $table->foreignId('id_empresa')
+                  ->constrained('empresas')
+                  ->onDelete('cascade');
+            $table->date('fecha');
+            $table->enum('estado', ['falta', 'asistencia', 'justificado']);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('listas');
+    }
+};

--- a/resources/views/alumno/partials/tareas.blade.php
+++ b/resources/views/alumno/partials/tareas.blade.php
@@ -64,13 +64,19 @@
                                 @endif
                             </div>
                         @else
-                            <div x-data="{ open: false }" class="mt-2">
+                            <div x-data="{ open: false, inputs: [1], add() { if(this.inputs.length < 4) this.inputs.push(Date.now()) }, remove(i){ this.inputs.splice(i,1) } }" class="mt-2">
                                 <button type="button" @click="open = !open" class="px-3 py-1 bg-green-600 text-white rounded shadow hover:bg-green-700">Entregar tarea</button>
                                 <div x-show="open" x-cloak class="mt-2 border rounded p-3 bg-white">
                                     <form method="POST" action="{{ route('alumno.entregar_tarea', $subtema->id) }}" enctype="multipart/form-data" class="space-y-2">
                                         @csrf
                                         <textarea name="contenido" rows="3" class="w-full border rounded p-2" placeholder="Contenido" required></textarea>
-                                        <input type="file" name="archivos[]" multiple class="w-full border rounded p-2">
+                                        <template x-for="(input, index) in inputs" :key="input">
+                                            <div class="flex items-center gap-2">
+                                                <input type="file" name="archivos[]" class="w-full border rounded p-2">
+                                                <button type="button" @click="remove(index)" class="text-red-600 text-sm">Eliminar</button>
+                                            </div>
+                                        </template>
+                                        <button type="button" @click="add" x-show="inputs.length < 4" class="px-2 py-1 bg-gray-200 rounded text-sm">Agregar archivo</button>
                                         <p class="text-xs text-gray-500">Máx. 4 archivos, 2MB cada uno.</p>
                                         <button type="submit" class="px-4 py-1 bg-blue-600 text-white rounded hover:bg-blue-700">Enviar</button>
                                     </form>


### PR DESCRIPTION
## Summary
- enable adding multiple task files individually in student view
- create `listas` table and new `Lista` model for attendance tracking

## Testing
- `composer test` *(fails: composer not found)*
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_684078f094108324859f4d7fec3d5eb5